### PR TITLE
Hotfix / Improve scores feed performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
+    nokogiri (1.11.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -229,6 +231,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/1

**Changes**

Fixed by reducing the queries count to 2 for every loading, even if the number of scores/users increases, using the .includes() query method which preloads the associated users alongside their scores.

**Before**

<img width="706" alt="141439450-199ebc68-12e7-4790-958a-be566ccd02a0" src="https://user-images.githubusercontent.com/104780342/174018980-7148bd61-ae27-4d0b-aa92-c830e1aadd90.png">

**After**

<img width="860" alt="Screenshot 2022-06-16 at 10 47 40" src="https://user-images.githubusercontent.com/104780342/174019898-7d552eea-b9c3-4b5e-badf-d5a4ef081a83.png">
